### PR TITLE
JWT/CWT claims and CBOR tag for CMWs

### DIFF
--- a/draft-ftbs-rats-msg-wrap.md
+++ b/draft-ftbs-rats-msg-wrap.md
@@ -41,6 +41,8 @@ normative:
   STD94:
     -: cbor
     =: RFC8949
+  IANA.cwt:
+  IANA.jwt:
 
 informative:
   RFC7942: impl-status
@@ -56,6 +58,9 @@ informative:
     title: "DICE Attestation Architecture"
     target: https://trustedcomputinggroup.org/wp-content/uploads/DICE-Attestation-Architecture-r23-final.pdf
     date: March, 2021
+
+entity:
+  SELF: "RFCthis"
 
 --- abstract
 
@@ -366,29 +371,30 @@ subsequently lead to a processing error.
 
 # IANA Considerations
 
-IANA is requested to register the following claims.
+[^rfced] replace "{{&SELF}}" with the RFC number assigned to this document.
 
-   // RFC editor: please remove this paragraph.
+## CWT `cmw` Claim Registration
 
-   RFC Editor: Please make the following adjustments and remove this
-   paragraph.  Replace "*this document*" with this RFC number.  In the
-   following, the claims with "Claim Key: TBD" need to be assigned a
-   value in the Specification Required Range, preferably around 299.
+IANA is requested to add a new `cmw` claim to the "CBOR Web Token (CWT) Claims" registry {{IANA.cwt}} as follows:
 
-   *  Claim Name: cmw
+* Claim Name: cmw
+* Claim Description: A RATS Conceptual Message wrapper
+* Claim Key: TBD
+* Claim Value Type(s): CBOR Array, or CBOR Tag
+* Change Controller: IETF
+* Specification Document(s): {{type-n-val}} and {{cbor-tag}} of {{&SELF}}
 
-   *  Claim Description: A conceptual message wrapper
+The suggested value for the Claim Key is 299.
 
-   *  JWT Claim Name: "cmw"
+## JWT `cmw` Claim Registration
 
-   *  CWT Claim Key: 299
+IANA is requested to add a new `cmw` claim to the "JSON Web Token Claims" sub-registry of the "JSON Web Token (JWT)" registry {{IANA.jwt}} as follows:
 
-   *  Claim Value Type(s): JSON Array, CBOR Array, or CBOR Tag
-
-   *  Change Controller: IETF
-
-   *  Specification Document(s): *this document*
-
+* Claim Name: cmw
+* Claim Description: A RATS Conceptual Message wrapper
+* Claim Value Type(s): JSON Array
+* Change Controller: IETF
+* Specification Document(s): {{type-n-val}} of {{&SELF}}
 
 --- back
 
@@ -451,3 +457,4 @@ reviews and suggestions.
 
 [^note]: Note:
 [^issue]: Open issue:
+[^rfced]: RFC Editor:

--- a/draft-ftbs-rats-msg-wrap.md
+++ b/draft-ftbs-rats-msg-wrap.md
@@ -75,7 +75,7 @@ message(s) are carried in the value.
 The other format wraps the value in a CBOR byte string and prepends a
 CBOR tag to convey the type information.
 
-An associated CBOR tag, as well as JWT and CWT claims are also defined to allow embedding these formats into CBOR-based protocols and web tokens.
+This document defines a corresponding CBOR tag, as well as JWT and CWT claims.  These allow embedding the wrapped conceptual messages into CBOR-based protocols and web tokens.
 
 --- middle
 

--- a/draft-ftbs-rats-msg-wrap.md
+++ b/draft-ftbs-rats-msg-wrap.md
@@ -366,7 +366,29 @@ subsequently lead to a processing error.
 
 # IANA Considerations
 
-This document does not make any requests to IANA.
+IANA is requested to register the following claims.
+
+   // RFC editor: please remove this paragraph.
+
+   RFC Editor: Please make the following adjustments and remove this
+   paragraph.  Replace "*this document*" with this RFC number.  In the
+   following, the claims with "Claim Key: TBD" need to be assigned a
+   value in the Specification Required Range, preferably around 299.
+
+   *  Claim Name: cmw
+
+   *  Claim Description: A conceptual message wrapper
+
+   *  JWT Claim Name: "cmw"
+
+   *  CWT Claim Key: 299
+
+   *  Claim Value Type(s): JSON Array, CBOR Array, or CBOR Tag
+
+   *  Change Controller: IETF
+
+   *  Specification Document(s): *this document*
+
 
 --- back
 

--- a/draft-ftbs-rats-msg-wrap.md
+++ b/draft-ftbs-rats-msg-wrap.md
@@ -25,7 +25,7 @@ author:
    organization: Intel
    email: ned.smith@intel.com
  - name: Thomas Fossati
-   organization: arm
+   organization: Linaro
    email: thomas.fossati@arm.com
  - name: Hannes Tschofenig
    email: hannes.tschofenig@gmx.net
@@ -75,7 +75,8 @@ message(s) are carried in the value.
 The other format wraps the value in a CBOR byte string and prepends a
 CBOR tag to convey the type information.
 
-This document defines a corresponding CBOR tag, as well as JWT and CWT claims.  These allow embedding the wrapped conceptual messages into CBOR-based protocols and web tokens.
+This document also defines a corresponding CBOR tag, as well as JWT and CWT claims.
+These allow embedding the wrapped conceptual messages into CBOR-based protocols and web tokens, respectively.
 
 --- middle
 

--- a/draft-ftbs-rats-msg-wrap.md
+++ b/draft-ftbs-rats-msg-wrap.md
@@ -75,6 +75,8 @@ message(s) are carried in the value.
 The other format wraps the value in a CBOR byte string and prepends a
 CBOR tag to convey the type information.
 
+An associated CBOR tag, as well as JWT and CWT claims are also defined to allow embedding these formats into CBOR-based protocols and web tokens.
+
 --- middle
 
 # Introduction
@@ -378,7 +380,7 @@ subsequently lead to a processing error.
 IANA is requested to add a new `cmw` claim to the "CBOR Web Token (CWT) Claims" registry {{IANA.cwt}} as follows:
 
 * Claim Name: cmw
-* Claim Description: A RATS Conceptual Message wrapper
+* Claim Description: A RATS Conceptual Message Wrapper
 * Claim Key: TBD
 * Claim Value Type(s): CBOR Array, or CBOR Tag
 * Change Controller: IETF
@@ -391,10 +393,18 @@ The suggested value for the Claim Key is 299.
 IANA is requested to add a new `cmw` claim to the "JSON Web Token Claims" sub-registry of the "JSON Web Token (JWT)" registry {{IANA.jwt}} as follows:
 
 * Claim Name: cmw
-* Claim Description: A RATS Conceptual Message wrapper
+* Claim Description: A RATS Conceptual Message Wrapper
 * Claim Value Type(s): JSON Array
 * Change Controller: IETF
 * Specification Document(s): {{type-n-val}} of {{&SELF}}
+
+## CBOR Tag Registration
+
+IANA is requested to add the following tag to the "CBOR Tags" {{!IANA.cbor-tags}} registry.
+
+| CBOR Tag | Data Item | Semantics | Reference |
+|----------|-----------|-----------|-----------|
+| TBD      | CBOR array, CBOR tag | RATS Conceptual Message Wrapper | {{type-n-val}} and {{cbor-tag}} of {{&SELF}} |
 
 --- back
 


### PR DESCRIPTION
Added IANA section for JWT and CWT registry entries for a 'cmw' element within a JWT or CWT. This allows any unsigned CMW message type definition to be included as a JWT or CWT payload.

Also added a CBOR tag for explicit typing of CBOR based serialisations (array and tag).

Fixes #25
Fixes #31 


