### PR TITLE
Extensibility rules for CM indicators

### DIFF
--- a/draft-ftbs-rats-msg-wrap.md
+++ b/draft-ftbs-rats-msg-wrap.md
@@ -41,6 +41,8 @@ normative:
   STD94:
     -: cbor
     =: RFC8949
+  IANA.cwt:
+  IANA.jwt:
 
 informative:
   RFC7942: impl-status
@@ -56,6 +58,9 @@ informative:
     title: "DICE Attestation Architecture"
     target: https://trustedcomputinggroup.org/wp-content/uploads/DICE-Attestation-Architecture-r23-final.pdf
     date: March, 2021
+
+entity:
+  SELF: "RFCthis"
 
 --- abstract
 
@@ -366,29 +371,30 @@ subsequently lead to a processing error.
 
 # IANA Considerations
 
-IANA is requested to register the following claims.
+[^rfced] replace "{{&SELF}}" with the RFC number assigned to this document.
 
-   // RFC editor: please remove this paragraph.
+## CWT `cmw` Claim Registration
 
-   RFC Editor: Please make the following adjustments and remove this
-   paragraph.  Replace "*this document*" with this RFC number.  In the
-   following, the claims with "Claim Key: TBD" need to be assigned a
-   value in the Specification Required Range, preferably around 299.
+IANA is requested to add a new `cmw` claim to the "CBOR Web Token (CWT) Claims" registry {{IANA.cwt}} as follows:
 
-   *  Claim Name: cmw
+* Claim Name: cmw
+* Claim Description: A RATS Conceptual Message wrapper
+* Claim Key: TBD
+* Claim Value Type(s): CBOR Array, or CBOR Tag
+* Change Controller: IETF
+* Specification Document(s): {{type-n-val}} and {{cbor-tag}} of {{&SELF}}
 
-   *  Claim Description: A conceptual message wrapper
+The suggested value for the Claim Key is 299.
 
-   *  JWT Claim Name: "cmw"
+## JWT `cmw` Claim Registration
 
-   *  CWT Claim Key: 299
+IANA is requested to add a new `cmw` claim to the "JSON Web Token Claims" sub-registry of the "JSON Web Token (JWT)" registry {{IANA.jwt}} as follows:
 
-   *  Claim Value Type(s): JSON Array, CBOR Array, or CBOR Tag
-
-   *  Change Controller: IETF
-
-   *  Specification Document(s): *this document*
-
+* Claim Name: cmw
+* Claim Description: A RATS Conceptual Message wrapper
+* Claim Value Type(s): JSON Array
+* Change Controller: IETF
+* Specification Document(s): {{type-n-val}} of {{&SELF}}
 
 --- back
 
@@ -451,3 +457,4 @@ reviews and suggestions.
 
 [^note]: Note:
 [^issue]: Open issue:
+[^rfced]: RFC Editor:

--- a/draft-ftbs-rats-msg-wrap.md
+++ b/draft-ftbs-rats-msg-wrap.md
@@ -75,7 +75,7 @@ message(s) are carried in the value.
 The other format wraps the value in a CBOR byte string and prepends a
 CBOR tag to convey the type information.
 
-An associated CBOR tag, as well as JWT and CWT claims are also defined to allow embedding these formats into CBOR-based protocols and web tokens.
+This document defines a corresponding CBOR tag, as well as JWT and CWT claims.  These allow embedding the wrapped conceptual messages into CBOR-based protocols and web tokens.
 
 --- middle
 

--- a/draft-ftbs-rats-msg-wrap.md
+++ b/draft-ftbs-rats-msg-wrap.md
@@ -366,7 +366,29 @@ subsequently lead to a processing error.
 
 # IANA Considerations
 
-This document does not make any requests to IANA.
+IANA is requested to register the following claims.
+
+   // RFC editor: please remove this paragraph.
+
+   RFC Editor: Please make the following adjustments and remove this
+   paragraph.  Replace "*this document*" with this RFC number.  In the
+   following, the claims with "Claim Key: TBD" need to be assigned a
+   value in the Specification Required Range, preferably around 299.
+
+   *  Claim Name: cmw
+
+   *  Claim Description: A conceptual message wrapper
+
+   *  JWT Claim Name: "cmw"
+
+   *  CWT Claim Key: 299
+
+   *  Claim Value Type(s): JSON Array, CBOR Array, or CBOR Tag
+
+   *  Change Controller: IETF
+
+   *  Specification Document(s): *this document*
+
 
 --- back
 

--- a/draft-ftbs-rats-msg-wrap.md
+++ b/draft-ftbs-rats-msg-wrap.md
@@ -78,7 +78,7 @@ message(s) are carried in the value.
 The other format wraps the value in a CBOR byte string and prepends a
 CBOR tag to convey the type information.
 
-This document defines a corresponding CBOR tag, as well as JWT and CWT claims.  These allow embedding the wrapped conceptual messages into CBOR-based protocols and web tokens.
+This document defines a corresponding CBOR tag, as well as JSON Web Tokens (JWT) and CBOR Web Tokens (CWT) claims.  These allow embedding the wrapped conceptual messages into CBOR-based protocols and web tokens.
 
 --- middle
 

--- a/draft-ftbs-rats-msg-wrap.md
+++ b/draft-ftbs-rats-msg-wrap.md
@@ -75,6 +75,8 @@ message(s) are carried in the value.
 The other format wraps the value in a CBOR byte string and prepends a
 CBOR tag to convey the type information.
 
+An associated CBOR tag, as well as JWT and CWT claims are also defined to allow embedding these formats into CBOR-based protocols and web tokens.
+
 --- middle
 
 # Introduction
@@ -378,7 +380,7 @@ subsequently lead to a processing error.
 IANA is requested to add a new `cmw` claim to the "CBOR Web Token (CWT) Claims" registry {{IANA.cwt}} as follows:
 
 * Claim Name: cmw
-* Claim Description: A RATS Conceptual Message wrapper
+* Claim Description: A RATS Conceptual Message Wrapper
 * Claim Key: TBD
 * Claim Value Type(s): CBOR Array, or CBOR Tag
 * Change Controller: IETF
@@ -391,10 +393,18 @@ The suggested value for the Claim Key is 299.
 IANA is requested to add a new `cmw` claim to the "JSON Web Token Claims" sub-registry of the "JSON Web Token (JWT)" registry {{IANA.jwt}} as follows:
 
 * Claim Name: cmw
-* Claim Description: A RATS Conceptual Message wrapper
+* Claim Description: A RATS Conceptual Message Wrapper
 * Claim Value Type(s): JSON Array
 * Change Controller: IETF
 * Specification Document(s): {{type-n-val}} of {{&SELF}}
+
+## CBOR Tag Registration
+
+IANA is requested to add the following tag to the "CBOR Tags" {{!IANA.cbor-tags}} registry.
+
+| CBOR Tag | Data Item | Semantics | Reference |
+|----------|-----------|-----------|-----------|
+| TBD      | CBOR array, CBOR tag | RATS Conceptual Message Wrapper | {{type-n-val}} and {{cbor-tag}} of {{&SELF}} |
 
 --- back
 

--- a/draft-ftbs-rats-msg-wrap.md
+++ b/draft-ftbs-rats-msg-wrap.md
@@ -43,6 +43,9 @@ normative:
     =: RFC8949
   IANA.cwt:
   IANA.jwt:
+  BCP26:
+    -: ianacons
+    =: RFC8126
 
 informative:
   RFC7942: impl-status
@@ -177,12 +180,12 @@ media type is not profiled (e.g., `application/eat+cwt`), if the `value`
 field contains multiple conceptual messages with different types (e.g.,
 both reference values and endorsements within the same `application/signed-corim+cbor`), or if the same profile identifier is
 shared by different conceptual messages.
-[^issue] https://github.com/thomas-fossati/draft-ftbs-rats-msg-wrap/issues/26
+Future specifications may add new values to the `ind` field; see {{iana-ind-ext}}.
 
 A CMW array can be encoded as CBOR {{-cbor}} or JSON {{-json}}.
 
 When using JSON, the value field is encoded as Base64 using the URL and
-filename safe alphabet (Section 5 of {{-base64}}) without padding.
+filename safe alphabet ({{Section 5 of -base64}}) without padding.
 
 When using CBOR, the value field is encoded as a CBOR byte string.
 
@@ -405,6 +408,42 @@ IANA is requested to add the following tag to the "CBOR Tags" {{!IANA.cbor-tags}
 | CBOR Tag | Data Item | Semantics | Reference |
 |----------|-----------|-----------|-----------|
 | TBD      | CBOR array, CBOR tag | RATS Conceptual Message Wrapper | {{type-n-val}} and {{cbor-tag}} of {{&SELF}} |
+
+## RATS Conceptual Message Wrapper (CMW) Indicators Registry {#iana-ind-ext}
+
+This specification defines a new "RATS Conceptual Message Wrapper (CMW) Indicators" registry, with the policy "Expert Review" ({{Section 4.5 of -ianacons}}).
+
+The objective is to have Indicators values registered for all RATS Conceptual Messages ({{Section 8 of -rats-arch}}).
+
+### Instructions for the Designated Expert {#de-instructions}
+
+The expert is instructed to add the values incrementally.
+
+Acceptable values are those corresponding to RATS Conceptual Messages defined by the RATS architecture {{-rats-arch}} and any of its updates.
+
+### Structure of Entries
+
+Each entry in the registry must include:
+
+{:vspace}
+Indicator value:
+: A number corresponding to the bit position in the `cm-ind` bitmap.
+
+Conceptual Message name:
+: A text string describing the RATS conceptual message this indicator corresponds to.
+
+Reference:
+: A reference to a document, if available, or the registrant.
+
+The initial registrations for the registry are detailed in {{tab-ind-regs}}.
+
+| Indicator value | Conceptual Message name | Reference |
+|-----------------|-------------------------|-----------|
+| 0 | Reference Values | {{&SELF}} |
+| 1 | Endorsements | {{&SELF}} |
+| 2 | Evidence | {{&SELF}} |
+| 3 | Attestation Results | {{&SELF}} |
+{: #tab-ind-regs title="CMW Indicators Registry Initial Contents"}
 
 --- back
 


### PR DESCRIPTION
Add IANA paraphernalia to handle registrations of new CM indicators.

Fix #26 


(This PR sits on top of #32, the relevant commit here is [2dddc46](https://github.com/thomas-fossati/draft-ftbs-rats-msg-wrap/pull/33/commits/2dddc46f5fa8030ee09425482c02043460fd3374))